### PR TITLE
fix safe parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This library is the successor to my old [clj-github](https://github.com/Raynes/c
 
 ## Usage
 
-This is on clojars, of course. Just add `[tentacles "0.3.0"]` to your `:dependencies` in your project.clj file.
+This is on clojars, of course. Just add `[tentacles "0.5.1"]` to your `:dependencies` in your project.clj file.
 
 ### CODE!
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Dependencies Status](https://jarkeeper.com/Raynes/tentacles/status.svg)](https://jarkeeper.com/Raynes/tentacles)
+
 # An octocat is nothing without her tentacles
 
 Tentacles is a Clojure library for working with the Github v3 API. It supports the entire Github API.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject tentacles "0.5.0"
+(defproject tentacles "0.5.1"
   :description "A library for working with the Github API."
   :url "https://github.com/Raynes/tentacles"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject tentacles "0.5.1"
+(defproject tentacles "0.5.2-SNAPSHOT"
   :description "A library for working with the Github API."
   :url "https://github.com/Raynes/tentacles"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [clj-http "1.0.1"]
-                 [cheshire "5.4.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [clj-http "3.1.0"]
+                 [cheshire "5.6.3"]
                  [com.cemerick/url "0.1.1"]
                  [org.clojure/data.codec "0.1.0"]
-                 [environ "1.0.0"]])
+                 [environ "1.1.0"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject tentacles "0.4.0"
+(defproject tentacles "0.5.0"
   :description "A library for working with the Github API."
   :url "https://github.com/Raynes/tentacles"
   :license {:name "Eclipse Public License"

--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -109,7 +109,7 @@
                           {:headers {"if-Modified-Since" if-modified-since}}))
         raw-query (:raw query)
         proper-query (query-map (dissoc query :auth :oauth-token :all-pages :accept :user-agent :otp))
-        req (if (#{:post :put :delete} method)
+        req (if (#{:post :put :delete :patch} method)
               (assoc req :body (json/generate-string (or raw-query proper-query)))
               (assoc req :query-params proper-query))]
     req))

--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -8,10 +8,10 @@
 (def ^:dynamic defaults {})
 
 (defn query-map
-  "Merge defaults, turn keywords into strings, and replace hyphens with underscores."
+  "Turn keywords into strings, and replace hyphens with underscores."
   [entries]
   (into {}
-        (for [[k v] (concat defaults entries)]
+        (for [[k v] entries]
           [(.replace (name k) "-" "_") v])))
 
 (defn parse-json
@@ -83,13 +83,13 @@
   [end-point positional]
   (str url (apply format end-point (map url/url-encode positional))))
 
-(defn make-request [method end-point positional
-                    {:keys [auth throw-exceptions follow-redirects accept
-                            oauth-token etag if-modified-since user-agent
-                            otp]
-                     :or {follow-redirects true throw-exceptions false}
-                     :as query}]
-  (let [req (merge-with merge
+(defn make-request [method end-point positional query]
+  (let [{:keys [auth throw-exceptions follow-redirects accept
+                oauth-token etag if-modified-since user-agent
+                otp]
+         :or {follow-redirects true throw-exceptions false}
+         :as query} (merge defaults query)
+        req (merge-with merge
                         {:url (format-url end-point positional)
                          :basic-auth auth
                          :throw-exceptions throw-exceptions

--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -44,6 +44,11 @@
   [obj]
   (:api-meta (meta obj)))
 
+(defn meta?
+  "True if metadata can be added to the object"
+  [x]
+  (instance? clojure.lang.IObj x))
+
 (defn safe-parse
   "Takes a response and checks for certain status codes. If 204, return nil.
    If 400, 401, 204, 422, 403, 404 or 500, return the original response with the body parsed
@@ -61,10 +66,9 @@
                metadata (extract-useful-meta headers)]
            (if-not (.contains content-type "raw")
              (let [parsed (parse-json body)]
-               (if (map? parsed)
+               (if (meta? parsed)
                  (with-meta parsed {:links links :api-meta metadata})
-                 (with-meta (map #(with-meta % metadata) parsed)
-                   {:links links :api-meta metadata})))
+                 parsed))
              body))))
 
 (defn update-req

--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -44,7 +44,7 @@
   [obj]
   (:api-meta (meta obj)))
 
-(defn meta?
+(defn- metadata-allowed?
   "True if metadata can be added to the object"
   [x]
   (instance? clojure.lang.IObj x))
@@ -66,7 +66,7 @@
                metadata (extract-useful-meta headers)]
            (if-not (.contains content-type "raw")
              (let [parsed (parse-json body)]
-               (if (meta? parsed)
+               (if (metadata-allowed? parsed)
                  (with-meta parsed {:links links :api-meta metadata})
                  parsed))
              body))))

--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -66,9 +66,10 @@
                metadata (extract-useful-meta headers)]
            (if-not (.contains content-type "raw")
              (let [parsed (parse-json body)]
-               (if (metadata-allowed? parsed)
-                 (with-meta parsed {:links links :api-meta metadata})
-                 parsed))
+               (cond
+                 (nil? parsed) (with-meta '() {:links links :api-meta metadata})
+                 (metadata-allowed? parsed) (with-meta parsed {:links links :api-meta metadata})
+                 :else parsed))
              body))))
 
 (defn update-req

--- a/src/tentacles/gists.clj
+++ b/src/tentacles/gists.clj
@@ -74,7 +74,7 @@
                      the name of the file. If one of the file keys in
                      the map is associated with 'nil', it'll be deleted."
   [id & [options]]
-  (api-call :post "gists/%s" [id] options))
+  (api-call :patch "gists/%s" [id] options))
 
 (defn star-gist
   "Star a gist."
@@ -123,7 +123,7 @@
 (defn edit-comment
   "Edit a comment."
   [comment-id body options]
-  (api-call :post "gists/comments/%s" [comment-id] (assoc options :body body)))
+  (api-call :patch "gists/comments/%s" [comment-id] (assoc options :body body)))
 
 (defn delete-comment
   "Delete a comment."

--- a/src/tentacles/gists.clj
+++ b/src/tentacles/gists.clj
@@ -96,7 +96,7 @@
 (defn fork-gist
   "Fork a gist."
   [id & [options]]
-  (api-call :post "gists/%s/fork" [id] options))
+  (api-call :post "gists/%s/forks" [id] options))
 
 (defn delete-gist
   "Delete a gist."

--- a/src/tentacles/issues.clj
+++ b/src/tentacles/issues.clj
@@ -92,7 +92,7 @@
      title     -- Title of the issue.
      body      -- The body text of the issue."
   [user repo id options]
-  (api-call :post "repos/%s/%s/issues/%s" [user repo id] options))
+  (api-call :patch "repos/%s/%s/issues/%s" [user repo id] options))
 
 ;; ## Issue Comments API
 
@@ -120,7 +120,7 @@
 (defn edit-comment
   "Edit a comment."
   [user repo comment-id body options]
-  (api-call :post "repos/%s/%s/issues/comments/%s"
+  (api-call :patch "repos/%s/%s/issues/comments/%s"
             [user repo comment-id] (assoc options :body body)))
 
 (defn delete-comment
@@ -173,7 +173,7 @@
 (defn edit-label
   "Edit a label."
   [user repo id name color options]
-  (api-call :post "repos/%s/%s/labels/%s"
+  (api-call :patch "repos/%s/%s/labels/%s"
             [user repo id] (assoc options :name name :color color)))
 
 (defn delete-label
@@ -242,7 +242,7 @@
      description -- a description string.
      due-on      -- String ISO 8601 timestamp"
   [user repo id title options]
-  (api-call :post "repos/%s/%s/milestones/%s"
+  (api-call :patch "repos/%s/%s/milestones/%s"
             [user repo id] (assoc options :title title)))
 
 (defn delete-milestone

--- a/src/tentacles/orgs.clj
+++ b/src/tentacles/orgs.clj
@@ -156,3 +156,47 @@
   "Remove a repo from a team."
   [id user repo options]
   (no-content? (api-call :delete "teams/%s/repos/%s/%s" [id user repo] options)))
+
+;; ## Org Hooks API
+
+(defn hooks
+  "List the hooks on an organization."
+  [org options]
+  (api-call :get "orgs/%s/hooks" [org] options))
+
+(defn specific-hook
+  "Get a specific hook."
+  [org id options]
+  (api-call :get "orgs/%s/hooks/%s" [org id] options))
+
+(defn create-hook
+  "Create a hook.
+   Options are:
+      events -- A sequence of event strings. Only 'push' by default.
+      active -- true or false; determines if the hook is actually triggered
+                on pushes."
+  [org config options]
+  (api-call :post "orgs/%s/hooks" [org]
+            (assoc options
+                   :name "web"
+                   :config config)))
+
+(defn edit-hook
+  "Edit an existing hook.
+   Options are:
+      config        -- Modified config.
+      events        -- A sequence of event strings. Replaces the events.
+      active        -- true or false; determines if the hook is actually
+                       triggered on pushes."
+  [org id options]
+  (api-call :patch "orgs/%s/hooks/%s" [org id] (assoc options :name "web")))
+
+(defn ping-hook
+  "Ping a hook."
+  [org id options]
+  (no-content? (api-call :post "orgs/%s/hooks/%s/pings" [org id] options)))
+
+(defn delete-hook
+  "Delete a hook."
+  [org id options]
+  (no-content? (api-call :delete "orgs/%s/hooks/%s" [org id] options)))

--- a/src/tentacles/orgs.clj
+++ b/src/tentacles/orgs.clj
@@ -188,8 +188,8 @@
       events        -- A sequence of event strings. Replaces the events.
       active        -- true or false; determines if the hook is actually
                        triggered on pushes."
-  [org id options]
-  (api-call :patch "orgs/%s/hooks/%s" [org id] (assoc options :name "web")))
+  [org id config options]
+  (api-call :patch "orgs/%s/hooks/%s" [org id] (assoc options :config config)))
 
 (defn ping-hook
   "Ping a hook."

--- a/src/tentacles/orgs.clj
+++ b/src/tentacles/orgs.clj
@@ -34,7 +34,7 @@
       location      -- Organization location.
       name          -- Name of the organization."
   [org options]
-  (api-call :post "orgs/%s" [org] options))
+  (api-call :patch "orgs/%s" [org] options))
 
 ;; ## Org Members API
 
@@ -110,7 +110,7 @@
                      push: team can push and pull but not admin.
                      admin: team can push, pull, and admin."
   [id options]
-  (api-call :post "teams/%s" [id] options))
+  (api-call :patch "teams/%s" [id] options))
 
 (defn delete-team
   "Delete a team."

--- a/src/tentacles/pulls.clj
+++ b/src/tentacles/pulls.clj
@@ -41,7 +41,7 @@
       body  -- a new body.
       state -- open or closed."
   [user repo id options]
-  (api-call :post "repos/%s/%s/pulls/%s" [user repo id] options))
+  (api-call :patch "repos/%s/%s/pulls/%s" [user repo id] options))
 
 (defn commits
   "List the commits on a pull request."
@@ -97,7 +97,7 @@
 (defn edit-comment
   "Edit a comment on a pull request."
   [user repo id body options]
-  (api-call :post "repos/%s/%s/pulls/comments/%s" [user repo id]
+  (api-call :patch "repos/%s/%s/pulls/comments/%s" [user repo id]
             (assoc options :body body)))
 
 (defn delete-comment

--- a/src/tentacles/repos.clj
+++ b/src/tentacles/repos.clj
@@ -566,6 +566,10 @@
   [user repo id & [options]]
   (api-call :get "repos/%s/%s/releases/%s" [user repo id] options))
 
+(defn specific-release-by-tag
+  "Gets a specific release by tag."
+  [user repo tag & [options]]
+  (api-call :get "repos/%s/%s/releases/tags/%s" [user repo tag] options))
 
 (defn create-release
   "Creates a release.

--- a/src/tentacles/repos.clj
+++ b/src/tentacles/repos.clj
@@ -558,8 +558,8 @@
 
 (defn releases
   "List releases for a repository."
-  [user repo]
-  (api-call :get "repos/%s/%s/releases" [user repo]))
+  [user repo & [options]]
+  (api-call :get "repos/%s/%s/releases" [user repo] options))
 
 (defn specific-release
   "Gets a specific release."

--- a/src/tentacles/repos.clj
+++ b/src/tentacles/repos.clj
@@ -79,7 +79,7 @@
       has-wiki      -- true, false.
       has-downloads -- true, false."
   [user repo options]
-  (api-call :post "repos/%s/%s"
+  (api-call :patch "repos/%s/%s"
             [user repo]
             (if (:name options)
               options
@@ -279,14 +279,6 @@
   (api-call :post "repos/%s/%s/keys" [user repo]
             (assoc options :title title :key key)))
 
-(defn edit-key
-  "Edit a deploy key.
-   Options are:
-      title -- New title.
-      key   -- New key."
-  [user repo id options]
-  (api-call :post "repos/%s/%s/keys/%s" [user repo id] options))
-
 (defn delete-key
   "Delete a deploy key."
   [user repo id options]
@@ -380,7 +372,7 @@
       active        -- true or false; determines if the hook is actually
                        triggered on pushes."
   [user repo id options]
-  (api-call :post "repos/%s/%s/hooks/%s" [user repo id] options))
+  (api-call :patch "repos/%s/%s/hooks/%s" [user repo id] options))
 
 (defn test-hook
   "Test a hook."

--- a/src/tentacles/repos.clj
+++ b/src/tentacles/repos.clj
@@ -464,9 +464,9 @@
    content -- The updated file content, Base64 encoded.
    sha -- The blob SHA of the file being replaced.
    Options are:
-      branch -- The branch name. Default: the repository’s default branch (usually master)
-      name -- The name of the author (or committer) of the commit
-      email -- The email of the author (or committer) of the commit"
+      branch    -- The branch name. Default: the repository’s default branch (usually master)
+      author    -- A map containing :name and :email for the author of the commit
+      committer -- A map containing :name and :email for the committer of the commit"
   [user repo path message content sha & [options]]
   (let [body (merge {:message message
                      :content (encode-b64 content)

--- a/src/tentacles/repos.clj
+++ b/src/tentacles/repos.clj
@@ -474,6 +474,21 @@
                     options)]
     (api-call :put "repos/%s/%s/contents/%s" [user repo path] body)))
 
+(defn delete-contents
+  "Delete a file in a repository
+   path    -- The content path.
+   message -- The commit message.
+   sha     -- The blob SHA of the file being deleted.
+   Options are:
+      branch    -- The branch name. Default: the repository’s default branch (usually master)
+      author    -- A map containing :name and :email for the author of the commit
+      committer -- A map containing :name and :email for the committer of the commit"
+  [user repo path message sha & [options]]
+  (let [body (merge {:message message
+                     :sha     sha}
+                    options)]
+    (api-call :delete "repos/%s/%s/contents/%s" [user repo path] body)))
+
 (defn archive-link
   "Get a URL to download a tarball or zipball archive for a repository.
    Options are:

--- a/src/tentacles/users.clj
+++ b/src/tentacles/users.clj
@@ -111,3 +111,8 @@
   "List the currently authenticated user's teams across all organizations"
   [& [options]]
   (api-call :get "user/teams" nil options))
+
+(defn repos
+  "All repositories for a user."
+  [user & [options]]
+  (api-call :get "users/%s/repos" [user] options))

--- a/src/tentacles/users.clj
+++ b/src/tentacles/users.clj
@@ -28,7 +28,7 @@
       hireable -- Looking for a job?
       bio      -- User's biography."
   [options]
-  (api-call :post "user" nil options))
+  (api-call :patch "user" nil options))
 
 (defn emails
   "List the authenticated user's emails."
@@ -101,14 +101,6 @@
   "Create a new public key."
   [title key options]
   (api-call :post "user/keys" nil (assoc options :title title :key key)))
-
-(defn edit-key
-  "Edit an existing public key.
-   Options are:
-      title -- New title.
-      key   -- New key."
-  [id options]
-  (api-call :post "user/keys/%s" [id] options))
 
 (defn delete-key
   "Delete a public key."

--- a/test/tentacles/core_test.clj
+++ b/test/tentacles/core_test.clj
@@ -2,6 +2,10 @@
   (:use clojure.test)
   (:require [tentacles.core :as core]))
 
+(deftest patch-requests-encode-json-body
+  (let [request (core/make-request :patch "foo" nil {:bar "baz"})]
+    (is (= (:body request) "{\"bar\":\"baz\"}"))))
+
 (deftest request-contains-user-agent
   (let [request (core/make-request :get "test" nil {:user-agent "Mozilla"})]
     (do

--- a/test/tentacles/core_test.clj
+++ b/test/tentacles/core_test.clj
@@ -4,9 +4,26 @@
 
 (deftest request-contains-user-agent
   (let [request (core/make-request :get "test" nil {:user-agent "Mozilla"})]
-    (do (is (empty?    (:query-params request)))
+    (do
+      (is (empty?    (:query-params request)))
       (is (contains? (:headers request) "User-Agent"))
       (is (= (get (:headers request) "User-Agent") "Mozilla")))))
+
+(deftest request-contains-user-agent-from-defaults
+  (core/with-defaults {:user-agent "Mozilla"}
+    (let [request (core/make-request :get "test" nil {})]
+      (do
+        (is (empty?    (:query-params request)))
+        (is (contains? (:headers request) "User-Agent"))
+        (is (= (get (:headers request) "User-Agent") "Mozilla"))))))
+
+(deftest adhoc-options-override-defaults
+  (core/with-defaults {:user-agent "default"}
+    (let [request (core/make-request :get "test" nil {:user-agent "adhoc"})]
+      (do
+        (is (empty?    (:query-params request)))
+        (is (contains? (:headers request) "User-Agent"))
+        (is (= (get (:headers request) "User-Agent") "adhoc"))))))
 
 (deftest hitting-rate-limit-is-propagated
   (is (= (:status (core/safe-parse {:status 403}))


### PR DESCRIPTION
- Don't try to add metadata to things that don't support it.
- When returning an API response that is a seq, add metadata to the response, not each item in the response.