### PR TITLE
CIRCLE-13527 - NOMERGE fix sending extraneous payload

### DIFF
--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -112,7 +112,7 @@
                         (when if-modified-since
                           {:headers {"if-Modified-Since" if-modified-since}}))
         raw-query (:raw query)
-        proper-query (query-map (dissoc query :auth :oauth-token :all-pages :accept :user-agent :otp))
+        proper-query (query-map (dissoc query :auth :oauth-token :all-pages :accept :user-agent :otp :throw-exceptions))
         req (if (#{:post :put :delete} method)
               (assoc req :body (json/generate-string (or raw-query proper-query)))
               (assoc req :query-params proper-query))]

--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -5,7 +5,8 @@
             [cemerick.url :as url]))
 
 (def ^:dynamic url "https://api.github.com/")
-(def ^:dynamic defaults {})
+(def ^:dynamic defaults {:follow-redirects true
+                         :throw-exceptions false})
 
 (defn query-map
   "Merge defaults, turn keywords into strings, and replace hyphens with underscores."
@@ -91,8 +92,8 @@
                     {:keys [auth throw-exceptions follow-redirects accept
                             oauth-token etag if-modified-since user-agent
                             otp]
-                     :or {follow-redirects (or (:follow-redirects defaults) true)
-                          throw-exceptions (or (:throw-exceptions defaults false))}
+                     :or {follow-redirects (:follow-redirects defaults)
+                          throw-exceptions (:throw-exceptions defaults)}
                      :as query}]
   (let [req (merge-with merge
                         {:url (format-url end-point positional)

--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -91,7 +91,8 @@
                     {:keys [auth throw-exceptions follow-redirects accept
                             oauth-token etag if-modified-since user-agent
                             otp]
-                     :or {follow-redirects true throw-exceptions false}
+                     :or {follow-redirects (or (:follow-redirects defaults) true)
+                          throw-exceptions (or (:throw-exceptions defaults false))}
                      :as query}]
   (let [req (merge-with merge
                         {:url (format-url end-point positional)

--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -11,7 +11,7 @@
   "Merge defaults, turn keywords into strings, and replace hyphens with underscores."
   [entries]
   (into {}
-        (for [[k v] (concat defaults entries)]
+        (for [[k v] entries]
           [(.replace (name k) "-" "_") v])))
 
 (defn parse-json
@@ -112,7 +112,7 @@
                         (when if-modified-since
                           {:headers {"if-Modified-Since" if-modified-since}}))
         raw-query (:raw query)
-        proper-query (query-map (dissoc query :auth :oauth-token :all-pages :accept :user-agent :otp :throw-exceptions))
+        proper-query (query-map (dissoc (merge defaults query) :auth :oauth-token :all-pages :accept :user-agent :otp :throw-exceptions))
         req (if (#{:post :put :delete} method)
               (assoc req :body (json/generate-string (or raw-query proper-query)))
               (assoc req :query-params proper-query))]


### PR DESCRIPTION
September 2018, GitHub will begin sending 422 status codes for certain post requests that contain extraneous payload data. This commit fixes this by removing the `:throw-exceptions` key from both the `:body` and `:query-params` that are sent to `clj-http.client/request`.

> Our API Engineering team is working on tightening up validation across the board in the GitHub API.
> 
> As part of this work, the team has been analyzing where the additional validation would cause integrator apps to break. This is will occur when the integrator is sending data that is invalid in some way. Previously, we've ignored these errors, but we will soon start enforcing stricter validation.
> 
> Specifically, in the case of CircleCI, we're seeing API calls that include a parameter, throw_exceptions, in the payloads of these three endpoints:
> 
> Create a public key (https://developer.github.com/v3/users/keys/#create-a-public-key)
> 
> Create a status (https://developer.github.com/v3/repos/statuses/#create-a-status)
> 
> Add a new deploy key (https://developer.github.com/v3/repos/keys/#add-a-new-deploy-key)
> 
> We will shortly start returning 422 Unprocessable Entity (https://httpstatuses.com/422) errors when we receive these request payloads.