### PR TITLE
CIRCLE-21513 added ability to configure http timeouts

### DIFF
--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -86,8 +86,8 @@
 (defn make-request [method end-point positional query]
   (let [{:keys [auth throw-exceptions follow-redirects accept
                 oauth-token etag if-modified-since user-agent
-                otp]
-         :or {follow-redirects true throw-exceptions false}
+                otp conn-timeout socket-timeout conn-request-timeout]
+         :or {follow-redirects true throw-exceptions false }
          :as query} (merge defaults query)
         req (merge-with merge
                         {:url (format-url end-point positional)
@@ -106,9 +106,15 @@
                         (when otp
                           {:headers {"X-GitHub-OTP" otp}})
                         (when if-modified-since
-                          {:headers {"if-Modified-Since" if-modified-since}}))
+                          {:headers {"if-Modified-Since" if-modified-since}})
+                        (when conn-timeout
+                          {:conn-timeout conn-timeout})
+                        (when socket-timeout
+                          {:socket-timeout socket-timeout})
+                        (when conn-request-timeout
+                          {:conn-request-timeout conn-request-timeout}))
         raw-query (:raw query)
-        proper-query (query-map (dissoc query :auth :oauth-token :all-pages :accept :user-agent :otp))
+        proper-query (query-map (dissoc query :auth :oauth-token :all-pages :accept :user-agent :otp :conn-timeout :socket-timeout :conn-request-timeout))
         req (if (#{:post :put :delete :patch} method)
               (assoc req :body (json/generate-string (or raw-query proper-query)))
               (assoc req :query-params proper-query))]

--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -87,7 +87,7 @@
   (let [{:keys [auth throw-exceptions follow-redirects accept
                 oauth-token etag if-modified-since user-agent
                 otp conn-timeout socket-timeout conn-request-timeout]
-         :or {follow-redirects true throw-exceptions false }
+         :or {follow-redirects true throw-exceptions false}
          :as query} (merge defaults query)
         req (merge-with merge
                         {:url (format-url end-point positional)


### PR DESCRIPTION
By default `clj-http` have indefinite timeouts therefore we might hang for a long time if github is having a bad time or there're some network issues. This allows callers to add timeouts.